### PR TITLE
Fix misleading RegEx type validation error message

### DIFF
--- a/ts/packages/ts/src/commands/EvalCommand.ts
+++ b/ts/packages/ts/src/commands/EvalCommand.ts
@@ -221,10 +221,14 @@ export class EvalCommand extends Command<EvalCommandReturn> {
         const evaluatedValue = current.result.value;
 
         if (!ConfigSchema.CFGU.TESTS.VAL_TYPE[cfgu.type]({ ...cfgu, value: evaluatedValue })) {
+          let suggestion = `value "${evaluatedValue}" must be a "${cfgu.type}"`;
+          if (cfgu.type === 'RegEx') {
+            suggestion = `value "${evaluatedValue}" must match the pattern ${cfgu.pattern}`;
+          }
           throw new Error(
             ERR(`invalid value type for key "${key}"`, {
               location: [`EvalCommand`, 'run'],
-              suggestion: `value "${evaluatedValue}" must be a "${cfgu.type}"`,
+              suggestion,
             }),
           );
         }


### PR DESCRIPTION
Solves issue #164 which @shini4i brought up regarding the misleading validation error in EvalCommand which is thrown when the value does not match the RegEx pattern. I took the suggested solution from the same issue from @rannn505 by adding a condition that changes the message if the type is RegEx. The message now explicitly says that the value must match the pattern and displays the pattern.