### PR TITLE
Fix validation of empty value during evaluation in @configu/ts

### DIFF
--- a/ts/packages/ts/src/commands/EvalCommand.ts
+++ b/ts/packages/ts/src/commands/EvalCommand.ts
@@ -220,7 +220,7 @@ export class EvalCommand extends Command<EvalCommandReturn> {
         const { key, cfgu } = current.context;
         const evaluatedValue = current.result.value;
 
-        if (!ConfigSchema.CFGU.TESTS.VAL_TYPE[cfgu.type]({ ...cfgu, value: evaluatedValue })) {
+        if (evaluatedValue && !ConfigSchema.CFGU.TESTS.VAL_TYPE[cfgu.type]({ ...cfgu, value: evaluatedValue })) {
           let suggestion = `value "${evaluatedValue}" must be a "${cfgu.type}"`;
           if (cfgu.type === 'RegEx') {
             suggestion = `value "${evaluatedValue}" must match the pattern ${cfgu.pattern}`;


### PR DESCRIPTION
Fixes #162. The validation always occurs regardless of the evaluated value which is incorrect, it should only occur if the evaluated value is not an empty string (an empty string represents an empty value which is always valid unless it is required, if it is, it will fail in the required validation at line 236) and that is the chosen strategy to fix this problem. A similar approach is taken in line 240 for the `depends` feature and this was the inspiration for the solution here.