### PR TITLE
Move `Keyv` to dependencies from dev dependencies

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -11642,8 +11642,7 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -11823,10 +11822,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
-      "dev": true,
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -19623,6 +19621,7 @@
         "@google-cloud/secret-manager": "^4.2.2",
         "@kubernetes/client-node": "^0.18.1",
         "axios": "^1.4.0",
+        "keyv": "^4.5.3",
         "lodash": "^4.17.21",
         "mssql": "^9.1.1",
         "mysql": "^2.18.1",
@@ -19632,8 +19631,7 @@
         "typeorm": "^0.3.16"
       },
       "devDependencies": {
-        "@types/lodash": "^4.14.195",
-        "keyv": "^4.5.2"
+        "@types/lodash": "^4.14.195"
       },
       "engines": {
         "node": ">=v16.0.0"
@@ -22217,7 +22215,7 @@
         "@kubernetes/client-node": "^0.18.1",
         "@types/lodash": "^4.14.195",
         "axios": "^1.4.0",
-        "keyv": "^4.5.2",
+        "keyv": "^4.5.3",
         "lodash": "^4.17.21",
         "mssql": "^9.1.1",
         "mysql": "^2.18.1",
@@ -28990,8 +28988,7 @@
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2"
@@ -29142,10 +29139,9 @@
       }
     },
     "keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
-      "dev": true,
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
       "requires": {
         "json-buffer": "3.0.1"
       }

--- a/ts/packages/node/package.json
+++ b/ts/packages/node/package.json
@@ -43,6 +43,7 @@
     "@google-cloud/secret-manager": "^4.2.2",
     "@kubernetes/client-node": "^0.18.1",
     "axios": "^1.4.0",
+    "keyv": "^4.5.3",
     "lodash": "^4.17.21",
     "mssql": "^9.1.1",
     "mysql": "^2.18.1",
@@ -52,7 +53,6 @@
     "typeorm": "^0.3.16"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.195",
-    "keyv": "^4.5.2"
+    "@types/lodash": "^4.14.195"
   }
 }


### PR DESCRIPTION
Following a recent discussion on correctly placing the `keyv` library in the `@configu/node` package.json, the placement should definitely be in the `dependencies` and not `devDependencies`. 