### PR TITLE
🎨 Implementing MongoDB ObjectID to Cfgu Type

### DIFF
--- a/go/generated.go
+++ b/go/generated.go
@@ -253,6 +253,7 @@ const (
 	MIMEType         CfguType = "MIMEType"
 	Md5              CfguType = "MD5"
 	MobilePhone      CfguType = "MobilePhone"
+	MongoId					 CfguType = "MongoId"	
 	Number           CfguType = "Number"
 	OracleRegion     CfguType = "OracleRegion"
 	RegEx            CfguType = "RegEx"

--- a/py/configu/core/config_schema.py
+++ b/py/configu/core/config_schema.py
@@ -264,6 +264,7 @@ class ConfigSchemaDefinition:
         "Language": pyvalidator.is_iso6391,
         "MACAddress": pyvalidator.is_mac_address,
         "MIMEType": pyvalidator.is_mime_type,
+        "MongoId": pyvalidator.is_mongo_id,
     }
     PROPS = list(Cfgu.__annotations__.keys())
 

--- a/py/configu/core/generated.py
+++ b/py/configu/core/generated.py
@@ -77,6 +77,7 @@ class CfguType(Enum):
     MD5 = "MD5"
     MIME_TYPE = "MIMEType"
     MOBILE_PHONE = "MobilePhone"
+    MONGOID = "MongoId"
     NUMBER = "Number"
     ORACLE_REGION = "OracleRegion"
     REG_EX = "RegEx"

--- a/ts/packages/ts/src/ConfigSchema.ts
+++ b/ts/packages/ts/src/ConfigSchema.ts
@@ -63,6 +63,7 @@ export abstract class ConfigSchema implements IConfigSchema {
           ),
         MACAddress: ({ value }) => validator.isMACAddress(value),
         MIMEType: ({ value }) => validator.isMimeType(value),
+        MongoId: ({ value }) => validator.isMongoId(value),
         AwsRegion: ({ value }) =>
           new Set([
             'af-south-1',

--- a/ts/packages/ts/src/types/generated.ts
+++ b/ts/packages/ts/src/types/generated.ts
@@ -32,7 +32,7 @@ export interface Cfgu {
     type:         CfguType;
 }
 
-export type CfguType = "AZRegion" | "AlibabaRegion" | "AwsRegion" | "Base64" | "Boolean" | "Color" | "ConnectionString" | "Country" | "Currency" | "DateTime" | "DockerImage" | "Domain" | "Email" | "GCPRegion" | "Hex" | "IBMRegion" | "IPv4" | "IPv6" | "Language" | "LatLong" | "Locale" | "MACAddress" | "MD5" | "MIMEType" | "MobilePhone" | "Number" | "OracleRegion" | "RegEx" | "SHA" | "SemVer" | "String" | "URL" | "UUID";
+export type CfguType = "AZRegion" | "AlibabaRegion" | "AwsRegion" | "Base64" | "Boolean" | "Color" | "ConnectionString" | "Country" | "Currency" | "DateTime" | "DockerImage" | "Domain" | "Email" | "GCPRegion" | "Hex" | "IBMRegion" | "IPv4" | "IPv6" | "Language" | "LatLong" | "Locale" | "MACAddress" | "MD5" | "MIMEType" | "MobilePhone" | "MongoId" | "Number" | "OracleRegion" | "RegEx" | "SHA" | "SemVer" | "String" | "URL" | "UUID";
 
 /**
  * A generic representation of a software configuration, aka Config
@@ -414,6 +414,7 @@ const typeMap: any = {
         "MIMEType",
         "MD5",
         "MobilePhone",
+        "MongoId",
         "Number",
         "OracleRegion",
         "RegEx",

--- a/ts/packages/vscode/public/cfgu.schema.json
+++ b/ts/packages/vscode/public/cfgu.schema.json
@@ -28,6 +28,7 @@
         "MD5",
         "MIMEType",
         "MobilePhone",
+        "MongoId",
         "Number",
         "OracleRegion",
         "RegEx",

--- a/types/Cfgu.ts
+++ b/types/Cfgu.ts
@@ -24,6 +24,7 @@ export type CfguType =
   | "DockerImage"
   | "MACAddress"
   | "MIMEType"
+  | "MongoId"
   | "AwsRegion"
   | "AZRegion"
   | "GCPRegion"


### PR DESCRIPTION
Changes includes:

- Added the MongoId type in Cfgu type
- Introduced the ENUM for mongoID in generated files for go, py & ts files
- Enforced validation on the newly added field in the validators file for go, py & ts files.