### PR TITLE
🎨 Implementing ARN Cfgu Type

### DIFF
--- a/go/config_schema.go
+++ b/go/config_schema.go
@@ -115,6 +115,8 @@ func anyInvalidDependencyNames(value ConfigSchemaContentsValue) bool {
 
 func validateCfguType(schema ConfigSchemaContentsValue, value string) bool {
 	switch schema.Type {
+	case ARN:
+		return isValidARN(value);
 	case Base64:
 		return isValidBase64(value)
 	case Boolean:
@@ -141,6 +143,8 @@ func validateCfguType(schema ConfigSchemaContentsValue, value string) bool {
 		return isValidLatLong(value)
 	case Md5:
 		return isValidMd5(value)
+	case MongoId:
+		return isValidMongoId(value)
 	case Number:
 		return isValidNumber(value)
 	case RegEx:
@@ -158,6 +162,10 @@ func validateCfguType(schema ConfigSchemaContentsValue, value string) bool {
 	default:
 		return false
 	}
+}
+
+func isValidARN(value string) bool {
+	return regexp.MustCompile(`^arn:([^:\n]+):([^:\n]+):(?:[^:\n]*):(?:([^:\n]*)):([^:\/\n]+)(?:(:[^\n]+)|(\/[^:\n]+))?$`).MatchString(value)
 }
 
 func isValidBase64(value string) bool {
@@ -258,6 +266,13 @@ func isValidLatLong(value string) bool {
 func isValidMd5(value string) bool {
 	type MyStruct struct {
 		Value string `validate:"required,md5"`
+	}
+	return validator.New().Struct(MyStruct{value}) == nil
+}
+
+func isValidMongoId(value string) bool {
+	type MyStruct struct {
+		Value string `validate:"required,mongodb"`
 	}
 	return validator.New().Struct(MyStruct{value}) == nil
 }

--- a/go/generated.go
+++ b/go/generated.go
@@ -261,6 +261,7 @@ const (
 	String           CfguType = "String"
 	URL              CfguType = "URL"
 	UUID             CfguType = "UUID"
+	ARN							 CfguType = "ARN"
 )
 
 type ConfigSchemaType string

--- a/go/generated.go
+++ b/go/generated.go
@@ -230,6 +230,7 @@ type CfguType string
 const (
 	AZRegion         CfguType = "AZRegion"
 	AlibabaRegion    CfguType = "AlibabaRegion"
+	Arn              CfguType = "ARN"
 	AwsRegion        CfguType = "AwsRegion"
 	Base64           CfguType = "Base64"
 	Boolean          CfguType = "Boolean"
@@ -262,7 +263,6 @@ const (
 	String           CfguType = "String"
 	URL              CfguType = "URL"
 	UUID             CfguType = "UUID"
-	ARN							 CfguType = "ARN"
 )
 
 type ConfigSchemaType string

--- a/py/configu/core/config_schema.py
+++ b/py/configu/core/config_schema.py
@@ -17,6 +17,7 @@ from ..utils import error_message, is_valid_name
 class ConfigSchemaDefinition:
     _cs_regex = r"^(?:([^:/?#\s]+):/{2})?(?:([^@/?#\s]+)@)?([^/?#\s]+)?(?:/([^?#\s]*))?(?:[?]([^#\s]+))?\S*$"  # noqa: E501
     _docker_regex = r"^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?\.)+[a-z]{2,6}(?::\d{1,5})?\/)?[a-z0-9]+(?:[._\-\/:][a-z0-9]+)*$"  # noqa: E501
+    _arn_regex = r"^arn:([^:\n]+):([^:\n]+):(?:[^:\n]*):(?:([^:\n]*)):([^:\/\n]+)(?:(:[^\n]+)|(\/[^:\n]+))?$"  # noqa: E501
     NAME: str = "cfgu"
     EXT: str = ".cfgu"
     VALIDATORS: Dict[str, Callable[[str], bool]] = {
@@ -257,6 +258,12 @@ class ConfigSchemaDefinition:
         },
         "DockerImage": lambda value: re.fullmatch(
             ConfigSchemaDefinition._docker_regex,
+            value,
+            re.RegexFlag.M,
+        )
+        is not None,
+        "ARN": lambda value: re.fullmatch(
+            ConfigSchemaDefinition._arn_regex,
             value,
             re.RegexFlag.M,
         )

--- a/py/configu/core/generated.py
+++ b/py/configu/core/generated.py
@@ -53,6 +53,7 @@ def from_dict(f: Callable[[Any], T], x: Any) -> Dict[str, T]:
 
 class CfguType(Enum):
     ALIBABA_REGION = "AlibabaRegion"
+    ARN = "ARN"
     AWS_REGION = "AwsRegion"
     AZ_REGION = "AZRegion"
     BASE64 = "Base64"
@@ -86,7 +87,6 @@ class CfguType(Enum):
     STRING = "String"
     URL = "URL"
     UUID = "UUID"
-    ARN = "ARN"
 
 
 @dataclass

--- a/py/configu/core/generated.py
+++ b/py/configu/core/generated.py
@@ -84,7 +84,8 @@ class CfguType(Enum):
     SHA = "SHA"
     STRING = "String"
     URL = "URL"
-    UUID = "UUID"
+    UUID = "UUID",
+    ARN = "ARN",
 
 
 @dataclass

--- a/py/configu/core/generated.py
+++ b/py/configu/core/generated.py
@@ -84,8 +84,8 @@ class CfguType(Enum):
     SHA = "SHA"
     STRING = "String"
     URL = "URL"
-    UUID = "UUID",
-    ARN = "ARN",
+    UUID = "UUID"
+    ARN = "ARN"
 
 
 @dataclass

--- a/ts/packages/ts/src/ConfigSchema.ts
+++ b/ts/packages/ts/src/ConfigSchema.ts
@@ -61,6 +61,11 @@ export abstract class ConfigSchema implements IConfigSchema {
           /^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?\.)+[a-z]{2,6}(?::\d{1,5})?\/)?[a-z0-9]+(?:[._\-\/:][a-z0-9]+)*$/gm.test(
             value,
           ),
+        ARN: ({ value }) =>
+          // eslint-disable-next-line no-useless-escape
+          /^arn:([^:\n]+):([^:\n]+):(?:[^:\n]*):(?:([^:\n]*)):([^:\/\n]+)(?:(:[^\n]+)|(\/[^:\n]+))?$/gm.test(
+            value,
+          ),
         MACAddress: ({ value }) => validator.isMACAddress(value),
         MIMEType: ({ value }) => validator.isMimeType(value),
         AwsRegion: ({ value }) =>

--- a/ts/packages/ts/src/types/generated.ts
+++ b/ts/packages/ts/src/types/generated.ts
@@ -32,7 +32,7 @@ export interface Cfgu {
     type:         CfguType;
 }
 
-export type CfguType = "AZRegion" | "AlibabaRegion" | "AwsRegion" | "Base64" | "Boolean" | "Color" | "ConnectionString" | "Country" | "Currency" | "DateTime" | "DockerImage" | "Domain" | "Email" | "GCPRegion" | "Hex" | "IBMRegion" | "IPv4" | "IPv6" | "Language" | "LatLong" | "Locale" | "MACAddress" | "MD5" | "MIMEType" | "MobilePhone" | "MongoId" | "Number" | "OracleRegion" | "RegEx" | "SHA" | "SemVer" | "String" | "URL" | "UUID" | "ARN";
+export type CfguType = "ARN" | "AZRegion" | "AlibabaRegion" | "AwsRegion" | "Base64" | "Boolean" | "Color" | "ConnectionString" | "Country" | "Currency" | "DateTime" | "DockerImage" | "Domain" | "Email" | "GCPRegion" | "Hex" | "IBMRegion" | "IPv4" | "IPv6" | "Language" | "LatLong" | "Locale" | "MACAddress" | "MD5" | "MIMEType" | "MobilePhone" | "MongoId" | "Number" | "OracleRegion" | "RegEx" | "SHA" | "SemVer" | "String" | "URL" | "UUID";
 
 /**
  * A generic representation of a software configuration, aka Config
@@ -391,6 +391,7 @@ const typeMap: any = {
     "CfguType": [
         "AZRegion",
         "AlibabaRegion",
+        "ARN",
         "AwsRegion",
         "Base64",
         "Boolean",
@@ -423,7 +424,6 @@ const typeMap: any = {
         "String",
         "URL",
         "UUID",
-        "ARN",
     ],
     "ConfigSchemaType": [
         "json",

--- a/ts/packages/ts/src/types/generated.ts
+++ b/ts/packages/ts/src/types/generated.ts
@@ -32,7 +32,7 @@ export interface Cfgu {
     type:         CfguType;
 }
 
-export type CfguType = "AZRegion" | "AlibabaRegion" | "AwsRegion" | "Base64" | "Boolean" | "Color" | "ConnectionString" | "Country" | "Currency" | "DateTime" | "DockerImage" | "Domain" | "Email" | "GCPRegion" | "Hex" | "IBMRegion" | "IPv4" | "IPv6" | "Language" | "LatLong" | "Locale" | "MACAddress" | "MD5" | "MIMEType" | "MobilePhone" | "Number" | "OracleRegion" | "RegEx" | "SHA" | "SemVer" | "String" | "URL" | "UUID";
+export type CfguType = "AZRegion" | "AlibabaRegion" | "AwsRegion" | "Base64" | "Boolean" | "Color" | "ConnectionString" | "Country" | "Currency" | "DateTime" | "DockerImage" | "Domain" | "Email" | "GCPRegion" | "Hex" | "IBMRegion" | "IPv4" | "IPv6" | "Language" | "LatLong" | "Locale" | "MACAddress" | "MD5" | "MIMEType" | "MobilePhone" | "Number" | "OracleRegion" | "RegEx" | "SHA" | "SemVer" | "String" | "URL" | "UUID" | "ARN";
 
 /**
  * A generic representation of a software configuration, aka Config
@@ -422,6 +422,7 @@ const typeMap: any = {
         "String",
         "URL",
         "UUID",
+        "ARN",
     ],
     "ConfigSchemaType": [
         "json",

--- a/ts/packages/vscode/public/cfgu.schema.json
+++ b/ts/packages/vscode/public/cfgu.schema.json
@@ -3,6 +3,7 @@
     "CfguType": {
       "title": "CfguType",
       "enum": [
+        "ARN",
         "AZRegion",
         "AlibabaRegion",
         "AwsRegion",

--- a/types/Cfgu.ts
+++ b/types/Cfgu.ts
@@ -31,7 +31,8 @@ export type CfguType =
   | "IBMRegion"
   | "AlibabaRegion"
   | "Language"
-  | "DateTime";
+  | "DateTime"
+  | "ARN";
 
 /**
  * A generic declaration of a Config, aka Cfgu that specifies information about its type and other characteristics


### PR DESCRIPTION
Changes include for https://github.com/configu/configu/issues/235:

- Adding ARN type to Cfgu.ts file
- Adding ENUMs for it in the respective file for go, ts & py
- Enforcing validation (Regex) for ARN in the respective validator files for go, ts & py
- Enforcing validation for MongoId in the validator file for go. Missed this as part of https://github.com/configu/configu/pull/242