### PR TITLE
Create fallback error message for not-implemented Cfgu types 

### DIFF
--- a/ts/packages/ts/src/commands/EvalCommand.ts
+++ b/ts/packages/ts/src/commands/EvalCommand.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { Command } from '../Command';
 import { Cfgu } from '../types';
-import { ERR, TMPL } from '../utils';
+import { ERR, TMPL, isStringInCfguType } from '../utils';
 import { ConfigStore } from '../ConfigStore';
 import { ConfigSet } from '../ConfigSet';
 import { ConfigSchema } from '../ConfigSchema';
@@ -101,6 +101,11 @@ export class EvalCommand extends Command<EvalCommandReturn> {
       const { context } = current;
       const { cfgu } = context;
 
+      if (!isStringInCfguType(current.context.schema)) {
+        throw new Error(
+          `Type '${current.context.schema}' is not yet supported in this SDK.\nFor the time being, please utilize the String type.\nWe'd greatly appreciate it if you could open an issue regarding this at https://github.com/configu/configu/issues/new/choose so we can address it in future updates.`,
+        );
+      }
       if (cfgu.template) {
         return {
           ...current,

--- a/ts/packages/ts/src/utils.ts
+++ b/ts/packages/ts/src/utils.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import Mustache from 'mustache';
+import type { CfguType } from './types';
 
 export const ERR = (
   message: string,
@@ -29,4 +30,47 @@ export const TMPL = {
     });
   },
   render: (template: string, context: any) => Mustache.render(template, context, {}, { escape: (value) => value }),
+};
+
+const cfguTypeSet = new Set<CfguType>([
+  'ARN',
+  'AWSRegion',
+  'AZRegion',
+  'AlibabaRegion',
+  'Base64',
+  'Boolean',
+  'Color',
+  'ConnectionString',
+  'Country',
+  'Currency',
+  'DateTime',
+  'DockerImage',
+  'Domain',
+  'Email',
+  'GCPRegion',
+  'Hex',
+  'IBMRegion',
+  'IPv4',
+  'IPv6',
+  'JSONSchema',
+  'Language',
+  'LatLong',
+  'Locale',
+  'MACAddress',
+  'MD5',
+  'MIMEType',
+  'MobilePhone',
+  'MongoId',
+  'Number',
+  'OracleRegion',
+  'RegEx',
+  'SHA',
+  'SemVer',
+  'String',
+  'URL',
+  'UUID',
+]);
+
+export const isStringInCfguType = (input: string): boolean => {
+  return cfguTypeSet.has(input as CfguType);
 };


### PR DESCRIPTION
This PR creates fallback error message for not-implemented `Cfgu types` in TS
Resolves #221 