### PR TITLE
Fix CLI partially upserting config values containing the `=` character

### DIFF
--- a/ts/packages/cli/src/base.ts
+++ b/ts/packages/cli/src/base.ts
@@ -153,11 +153,11 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
 
     return _(configFlag)
       .map((pair, idx) => {
-        const [key, value] = pair.split('=');
+        const [key, ...rest] = pair.split('=');
         if (!key) {
           throw new Error(`config key is missing at --config[${idx}]`);
         }
-        return { key, value: value ?? '' };
+        return { key, value: rest.join('=') ?? '' };
       })
       .keyBy('key')
       .mapValues('value')


### PR DESCRIPTION
Resolves #259 