### PR TITLE
use import type instead of import

### DIFF
--- a/ts/packages/cli/src/base.ts
+++ b/ts/packages/cli/src/base.ts
@@ -1,14 +1,14 @@
 import os from 'os';
 import fs from 'fs/promises';
 import path from 'path';
-import { Config, Command, Flags, Interfaces, Errors, ux } from '@oclif/core';
+import { type Config, Command, type Flags, type Interfaces, Errors, ux } from '@oclif/core';
 import _ from 'lodash';
 import { cosmiconfig } from 'cosmiconfig';
 import axios from 'axios';
 import chalk from 'chalk';
 import logSymbols from 'log-symbols';
 import ci from 'ci-info';
-import { EvalCommandReturn, ConfiguConfigStore, TMPL } from '@configu/ts';
+import { type EvalCommandReturn, type ConfiguConfigStore, TMPL } from '@configu/ts';
 import { constructStore } from './helpers';
 
 type BaseConfig = Config & {

--- a/ts/packages/cli/src/commands/eval.ts
+++ b/ts/packages/cli/src/commands/eval.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core';
-import { EvalCommandParameters } from '@configu/ts';
+import { type EvalCommandParameters } from '@configu/ts';
 import { NoopConfigStore, ConfigSet, ConfigSchema, EvalCommand } from '@configu/node';
 import { BaseCommand } from '../base';
 

--- a/ts/packages/cli/src/commands/export.ts
+++ b/ts/packages/cli/src/commands/export.ts
@@ -2,9 +2,9 @@ import { cwd } from 'process';
 import { spawnSync } from 'child_process';
 import { Flags, ux } from '@oclif/core';
 import _ from 'lodash';
-import { TMPL, EvalCommandReturn, EvaluatedConfigOrigin, ExportCommandReturn } from '@configu/ts';
+import { TMPL, type EvalCommandReturn, EvaluatedConfigOrigin, type ExportCommandReturn } from '@configu/ts';
 import { ExportCommand } from '@configu/node';
-import { CONFIG_FORMAT_TYPE, formatConfigs, ConfigFormat } from '@configu/lib';
+import { CONFIG_FORMAT_TYPE, formatConfigs, type ConfigFormat } from '@configu/lib';
 import { BaseCommand } from '../base';
 
 export const NO_CONFIGS_WARNING_TEXT = 'no configuration was fetched';

--- a/ts/packages/cli/src/commands/init.ts
+++ b/ts/packages/cli/src/commands/init.ts
@@ -4,7 +4,7 @@ import { cwd } from 'process';
 import { Flags } from '@oclif/core';
 import _ from 'lodash';
 import { paramCase } from 'change-case';
-import { Cfgu } from '@configu/ts';
+import { type Cfgu } from '@configu/ts';
 import { extractConfigs, GET_STARTED, FOO } from '@configu/lib';
 import { ConfigSchema } from '@configu/node';
 import { BaseCommand } from '../base';

--- a/ts/packages/cli/src/helpers/stores.ts
+++ b/ts/packages/cli/src/helpers/stores.ts
@@ -1,5 +1,5 @@
-import { ConfigStore } from '@configu/ts';
-import { StoreType } from '@configu/lib';
+import { type ConfigStore } from '@configu/ts';
+import { type StoreType } from '@configu/lib';
 import {
   AWSParameterStoreConfigStore,
   AWSSecretsManagerConfigStore,

--- a/ts/packages/lib/src/extractors/configAnalyzer.ts
+++ b/ts/packages/lib/src/extractors/configAnalyzer.ts
@@ -1,4 +1,4 @@
-import { CfguType, ConfigSchema } from '@configu/ts';
+import { type CfguType, ConfigSchema } from '@configu/ts';
 
 // * when adding a new type, update typeCheckOrder array
 export const TYPES_CHECK_ORDER: CfguType[] = [

--- a/ts/packages/lib/src/extractors/configExtractors.ts
+++ b/ts/packages/lib/src/extractors/configExtractors.ts
@@ -1,8 +1,8 @@
-import { Cfgu, Config } from '@configu/ts';
+import { type Cfgu, type Config } from '@configu/ts';
 import Dotenv from 'dotenv';
 import _ from 'lodash';
 import { analyzeValueType } from './configAnalyzer';
-import { ConfigFormat, CONFIG_FORMAT_EXTENSION } from '../formatters';
+import { type ConfigFormat, CONFIG_FORMAT_EXTENSION } from '../formatters';
 
 type ConfigExtractorFormat = Extract<ConfigFormat, 'JSON' | 'Dotenv'>;
 

--- a/ts/packages/lib/src/formatters/configFormatters.ts
+++ b/ts/packages/lib/src/formatters/configFormatters.ts
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import { camelCase, snakeCase } from 'change-case';
 import { dump as ymlStringify } from 'js-yaml';
 import validator from 'validator';
-import type { ExportCommandReturn } from '@configu/ts';
-import type { ConfigFormat } from './ConfigFormat';
+import { type ExportCommandReturn } from '@configu/ts';
+import { type ConfigFormat } from './ConfigFormat';
 
 const hasWhitespace = (str: string) => {
   return /\s/.test(str);

--- a/ts/packages/lib/src/integrations/store.ts
+++ b/ts/packages/lib/src/integrations/store.ts
@@ -1,4 +1,4 @@
-import { LiteralUnion } from 'type-fest';
+import { type LiteralUnion } from 'type-fest';
 
 export type StoreType = LiteralUnion<
   | 'noop'

--- a/ts/packages/lib/src/schemas/foo.ts
+++ b/ts/packages/lib/src/schemas/foo.ts
@@ -1,4 +1,4 @@
-import { Cfgu } from '@configu/ts';
+import { type Cfgu } from '@configu/ts';
 
 export const FOO: { [key: string]: Cfgu } = {
   FOO: { type: 'String', default: 'foo', description: 'string example variable' },

--- a/ts/packages/lib/src/schemas/getStarted.ts
+++ b/ts/packages/lib/src/schemas/getStarted.ts
@@ -1,4 +1,4 @@
-import { Cfgu } from '@configu/ts';
+import { type Cfgu } from '@configu/ts';
 
 export const GET_STARTED: { [key: string]: Cfgu } = {
   GREETING: {

--- a/ts/packages/node/src/commands/ExportCommand.ts
+++ b/ts/packages/node/src/commands/ExportCommand.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {
   ExportCommand as BaseExportCommand,
-  ExportCommandParameters as BaseExportCommandParameters,
+  type ExportCommandParameters as BaseExportCommandParameters,
 } from '@configu/ts';
 
 type ExportCommandParameters = BaseExportCommandParameters & {

--- a/ts/packages/node/src/stores/AWSParameterStore.ts
+++ b/ts/packages/node/src/stores/AWSParameterStore.ts
@@ -1,6 +1,6 @@
 import {
   SSMClient,
-  SSMClientConfig,
+  type SSMClientConfig,
   DeleteParameterCommand,
   GetParameterCommand,
   PutParameterCommand,

--- a/ts/packages/node/src/stores/AWSSecretsManager.ts
+++ b/ts/packages/node/src/stores/AWSSecretsManager.ts
@@ -1,6 +1,6 @@
 import {
   SecretsManagerClient,
-  SecretsManagerClientConfig,
+  type SecretsManagerClientConfig,
   GetSecretValueCommand,
   UpdateSecretCommand,
   CreateSecretCommand,

--- a/ts/packages/node/src/stores/AzureKeyVault.ts
+++ b/ts/packages/node/src/stores/AzureKeyVault.ts
@@ -1,5 +1,5 @@
-import { DefaultAzureCredential, DefaultAzureCredentialClientIdOptions } from '@azure/identity';
-import { SecretClient, SecretClientOptions } from '@azure/keyvault-secrets';
+import { DefaultAzureCredential, type DefaultAzureCredentialClientIdOptions } from '@azure/identity';
+import { SecretClient, type SecretClientOptions } from '@azure/keyvault-secrets';
 import { KeyValueConfigStore } from '@configu/ts';
 
 export type AzureKeyVaultConfigStoreConfiguration = {

--- a/ts/packages/node/src/stores/CockroachDB.ts
+++ b/ts/packages/node/src/stores/CockroachDB.ts
@@ -1,4 +1,4 @@
-import { CockroachConnectionOptions } from 'typeorm/driver/cockroachdb/CockroachConnectionOptions';
+import { type CockroachConnectionOptions } from 'typeorm/driver/cockroachdb/CockroachConnectionOptions';
 import { ORMConfigStore } from './ORM';
 
 export type CockroachDBConfigStoreConfiguration = Omit<CockroachConnectionOptions, 'type'>;

--- a/ts/packages/node/src/stores/Etcd.ts
+++ b/ts/packages/node/src/stores/Etcd.ts
@@ -1,5 +1,5 @@
 import { KeyValueConfigStore } from '@configu/ts';
-import { Etcd3, IOptions } from 'etcd3';
+import { Etcd3, type IOptions } from 'etcd3';
 
 export type EtcdConfigStoreConfiguration = IOptions;
 

--- a/ts/packages/node/src/stores/HashiCorpVault.ts
+++ b/ts/packages/node/src/stores/HashiCorpVault.ts
@@ -1,4 +1,4 @@
-import axios, { Axios } from 'axios';
+import axios, { type Axios } from 'axios';
 import { KeyValueConfigStore } from '@configu/ts';
 
 export type HashiCorpVaultConfigStoreConfiguration = { address?: string; token?: string; engine: string };

--- a/ts/packages/node/src/stores/IniFile.ts
+++ b/ts/packages/node/src/stores/IniFile.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import _ from 'lodash';
 import ini from 'ini';
-import { ConfigStore, ConfigStoreQuery, Config } from '@configu/ts';
+import { ConfigStore, type ConfigStoreQuery, type Config } from '@configu/ts';
 
 export type IniFileConfigStoreConfiguration = { path: string };
 

--- a/ts/packages/node/src/stores/JsonFile.ts
+++ b/ts/packages/node/src/stores/JsonFile.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import _ from 'lodash';
-import { ConfigStore, ConfigStoreQuery, Config, Convert } from '@configu/ts';
+import { ConfigStore, type ConfigStoreQuery, type Config, Convert } from '@configu/ts';
 
 export type JsonFileConfigStoreConfiguration = { path: string };
 

--- a/ts/packages/node/src/stores/LaunchDarkly.ts
+++ b/ts/packages/node/src/stores/LaunchDarkly.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
-import { Config, ConfigStore, ConfigStoreQuery } from '@configu/ts';
-import axios, { Axios } from 'axios';
+import { type Config, ConfigStore, type ConfigStoreQuery } from '@configu/ts';
+import axios, { type Axios } from 'axios';
 import _ from 'lodash';
 
 export interface LaunchDarklyConfigStoreParams {

--- a/ts/packages/node/src/stores/MSSQL.ts
+++ b/ts/packages/node/src/stores/MSSQL.ts
@@ -1,4 +1,4 @@
-import { SqlServerConnectionOptions } from 'typeorm/driver/sqlserver/SqlServerConnectionOptions';
+import { type SqlServerConnectionOptions } from 'typeorm/driver/sqlserver/SqlServerConnectionOptions';
 import { ORMConfigStore } from './ORM';
 
 export type MSSQLConfigStoreConfiguration = Omit<SqlServerConnectionOptions, 'type'>;

--- a/ts/packages/node/src/stores/MariaDB.ts
+++ b/ts/packages/node/src/stores/MariaDB.ts
@@ -1,4 +1,4 @@
-import { MysqlConnectionOptions } from 'typeorm/driver/mysql/MysqlConnectionOptions';
+import { type MysqlConnectionOptions } from 'typeorm/driver/mysql/MysqlConnectionOptions';
 import { ORMConfigStore } from './ORM';
 
 // * TypeORM uses the mysql driver under the hood for MariaDB

--- a/ts/packages/node/src/stores/MySQL.ts
+++ b/ts/packages/node/src/stores/MySQL.ts
@@ -1,4 +1,4 @@
-import { MysqlConnectionOptions } from 'typeorm/driver/mysql/MysqlConnectionOptions';
+import { type MysqlConnectionOptions } from 'typeorm/driver/mysql/MysqlConnectionOptions';
 import { ORMConfigStore } from './ORM';
 
 export type MySQLConfigStoreConfiguration = Omit<MysqlConnectionOptions, 'type'>;

--- a/ts/packages/node/src/stores/ORM.ts
+++ b/ts/packages/node/src/stores/ORM.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
-import { ConfigStore, ConfigStoreQuery, Config as IConfig } from '@configu/ts';
-import { Entity, Column, DataSource, DataSourceOptions, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { ConfigStore, type ConfigStoreQuery, type Config as IConfig } from '@configu/ts';
+import { Entity, Column, DataSource, type DataSourceOptions, Index, PrimaryGeneratedColumn } from 'typeorm';
 import _ from 'lodash';
 
 @Entity()

--- a/ts/packages/node/src/stores/PostgreSQL.ts
+++ b/ts/packages/node/src/stores/PostgreSQL.ts
@@ -1,4 +1,4 @@
-import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
+import { type PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 import { ORMConfigStore } from './ORM';
 
 export type PostgreSQLConfigStoreConfiguration = Omit<PostgresConnectionOptions, 'type'>;

--- a/ts/packages/node/src/stores/SQLite.ts
+++ b/ts/packages/node/src/stores/SQLite.ts
@@ -1,4 +1,4 @@
-import { SqliteConnectionOptions } from 'typeorm/driver/sqlite/SqliteConnectionOptions';
+import { type SqliteConnectionOptions } from 'typeorm/driver/sqlite/SqliteConnectionOptions';
 import { ORMConfigStore } from './ORM';
 
 export type SQLiteConfigStoreConfiguration = Omit<SqliteConnectionOptions, 'type'>;

--- a/ts/packages/ts/src/ConfigSchema.ts
+++ b/ts/packages/ts/src/ConfigSchema.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import validator from 'validator';
 import Ajv, { JSONSchemaType } from 'ajv';
-import { IConfigSchema, ConfigSchemaType, Cfgu, CfguType, Convert } from './types';
-import { ERR, NAME, TMPL } from './utils';
+import { type IConfigSchema, type ConfigSchemaType, type Cfgu, type CfguType, Convert } from './types';
+import { ERR, NAME, type TMPL } from './utils';
 
 const ajv = new Ajv();
 type CfguPath = `${string}.cfgu.${ConfigSchemaType}`;

--- a/ts/packages/ts/src/ConfigSet.ts
+++ b/ts/packages/ts/src/ConfigSet.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { IConfigSet } from './types';
+import { type IConfigSet } from './types';
 import { ERR, NAME } from './utils';
 
 export class ConfigSet implements IConfigSet {

--- a/ts/packages/ts/src/ConfigStore.ts
+++ b/ts/packages/ts/src/ConfigStore.ts
@@ -1,4 +1,4 @@
-import { IConfigStore, ConfigStoreQuery, Config } from './types';
+import { type IConfigStore, type ConfigStoreQuery, type Config } from './types';
 
 export abstract class ConfigStore implements IConfigStore {
   constructor(public readonly type: string) {}

--- a/ts/packages/ts/src/commands/DeleteCommand.ts
+++ b/ts/packages/ts/src/commands/DeleteCommand.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import { Command } from '../Command';
-import { Config } from '../types';
+import { type Config } from '../types';
 import { ERR } from '../utils';
-import { ConfigStore } from '../ConfigStore';
-import { ConfigSet } from '../ConfigSet';
+import { type ConfigStore } from '../ConfigStore';
+import { type ConfigSet } from '../ConfigSet';
 import { ConfigSchema } from '../ConfigSchema';
 
 export type DeleteCommandParameters = {

--- a/ts/packages/ts/src/commands/EvalCommand.ts
+++ b/ts/packages/ts/src/commands/EvalCommand.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import { Command } from '../Command';
-import { Cfgu } from '../types';
+import { type Cfgu } from '../types';
 import { ERR, TMPL } from '../utils';
-import { ConfigStore } from '../ConfigStore';
+import { type ConfigStore } from '../ConfigStore';
 import { ConfigSet } from '../ConfigSet';
 import { ConfigSchema } from '../ConfigSchema';
 

--- a/ts/packages/ts/src/commands/ExportCommand.ts
+++ b/ts/packages/ts/src/commands/ExportCommand.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { Command } from '../Command';
-import { EvalCommandReturn } from './EvalCommand';
+import { type EvalCommandReturn } from './EvalCommand';
 
 export type ExportCommandReturn = {
   [key: string]: string;

--- a/ts/packages/ts/src/commands/TestCommand.ts
+++ b/ts/packages/ts/src/commands/TestCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from '../Command';
-import { ConfigStore } from '../ConfigStore';
+import { type ConfigStore } from '../ConfigStore';
 import { ConfigSet } from '../ConfigSet';
 import { InMemoryConfigSchema } from '../ConfigSchema';
 import { UpsertCommand } from './UpsertCommand';

--- a/ts/packages/ts/src/commands/UpsertCommand.ts
+++ b/ts/packages/ts/src/commands/UpsertCommand.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import { Command } from '../Command';
-import { Config } from '../types';
+import { type Config } from '../types';
 import { ERR } from '../utils';
-import { ConfigStore } from '../ConfigStore';
-import { ConfigSet } from '../ConfigSet';
+import { type ConfigStore } from '../ConfigStore';
+import { type ConfigSet } from '../ConfigSet';
 import { ConfigSchema } from '../ConfigSchema';
 
 export type UpsertCommandParameters = {

--- a/ts/packages/ts/src/commands/commands.test.ts
+++ b/ts/packages/ts/src/commands/commands.test.ts
@@ -4,11 +4,11 @@ import {
   ConfigSet,
   InMemoryConfigSchema,
   UpsertCommand,
-  UpsertCommandParameters,
+  type UpsertCommandParameters,
   EvalCommand,
-  EvalCommandParameters,
+  type EvalCommandParameters,
   DeleteCommand,
-  EvalCommandReturn,
+  type EvalCommandReturn,
 } from '..';
 
 describe(`commands`, () => {

--- a/ts/packages/ts/src/stores/Configu.ts
+++ b/ts/packages/ts/src/stores/Configu.ts
@@ -1,7 +1,7 @@
-import axios, { Axios } from 'axios';
+import axios, { type Axios } from 'axios';
 import validator from 'validator';
 import { ConfigStore } from '../ConfigStore';
-import { ConfigStoreQuery, Config } from '../types';
+import { type ConfigStoreQuery, type Config } from '../types';
 
 export type ConfiguConfigStoreConfiguration = {
   credentials: { org: string; token: string };

--- a/ts/packages/ts/src/stores/InMemory.ts
+++ b/ts/packages/ts/src/stores/InMemory.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { ConfigStore } from '../ConfigStore';
-import { ConfigStoreQuery, Config } from '../types';
+import { type ConfigStoreQuery, type Config } from '../types';
 
 export class InMemoryConfigStore extends ConfigStore {
   private data: Config[] = [];

--- a/ts/packages/ts/src/stores/KeyValue.ts
+++ b/ts/packages/ts/src/stores/KeyValue.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { ConfigStore } from '../ConfigStore';
-import { Config, ConfigStoreQuery } from '../types';
+import { type Config, type ConfigStoreQuery } from '../types';
 
 export abstract class KeyValueConfigStore extends ConfigStore {
   constructor(type: string) {

--- a/ts/packages/ts/src/stores/Noop.ts
+++ b/ts/packages/ts/src/stores/Noop.ts
@@ -1,5 +1,5 @@
 import { ConfigStore } from '../ConfigStore';
-import { ConfigStoreQuery, Config } from '../types';
+import { type ConfigStoreQuery, type Config } from '../types';
 
 export class NoopConfigStore extends ConfigStore {
   constructor() {

--- a/types/ConfigSchema.ts
+++ b/types/ConfigSchema.ts
@@ -1,4 +1,4 @@
-import { Cfgu } from './Cfgu';
+import { type Cfgu } from './Cfgu';
 
 export type ConfigSchemaType = "json";
 

--- a/types/ConfigStore.ts
+++ b/types/ConfigStore.ts
@@ -1,4 +1,4 @@
-import { Config } from './Config';
+import { type Config } from './Config';
 
 /**
  * An interface of a storage, aka ConfigStore


### PR DESCRIPTION
## Description
This PR addresses an issue where TypeScript files earlier used the `import` syntax instead of the more specific `import type`. The `import type` syntax in TypeScript is used to import only the types from a module, rather than the entire module which can be useful for quite a few reasons.

Key Changes:
- Updated TypeScript files to use the `import type` syntax.
- The imports which were unused were left untouched due to ambiguity regarding their purpose.

Closes: #207
