### PR TITLE
Allow provision of a default store

### DIFF
--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -19,7 +19,6 @@ export default class Delete extends BaseCommand<typeof Delete> {
   static flags = {
     store: Flags.string({
       description: `\`ConfigStore\` (configs data-source) to delete \`Configs\` from`,
-      required: true,
       aliases: ['st'],
     }),
     set: Flags.string({

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -19,7 +19,6 @@ export default class Test extends BaseCommand<typeof Test> {
   static flags = {
     store: Flags.string({
       description: `\`ConfigStore\` (configs data-source) to upsert \`CONFIGU_TEST\` config to`,
-      required: true,
       aliases: ['st'],
     }),
     clean: Flags.boolean({

--- a/packages/cli/src/commands/upsert.ts
+++ b/packages/cli/src/commands/upsert.ts
@@ -30,7 +30,6 @@ export default class Upsert extends BaseCommand<typeof Upsert> {
   static flags = {
     store: Flags.string({
       description: `\`ConfigStore\` (configs data-source) to upsert \`Configs\` to`,
-      required: true,
       aliases: ['st'],
     }),
     set: Flags.string({


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the pull request (PR) is created. -->

<!--
Thank you for contributing to Configu! We really appreciate your efforts to make Configu better.

Looking to send a PR? Awesome! You can find many issues labeled as `help wanted` or `good first issue` in our issue tracker.
  https://github.com/configu/configu/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22%2C%22help+wanted%22

Before you send over your PR, let's ensure it’s all set for a smooth review. Here’s a quick checklist:

Please verify that:
* [ ] The PR has a clear title and a concise summary of the changes (Use the present tense and imperative mood for your descriptions)
* [ ] Related issues are linked using `Closes #number`
* [ ] Code is up-to-date with the `main` branch
* [ ] There are no linting or formatting errors
* [ ] There are new or updated unit tests validating the change

For more details, have a look at our CONTRIBUTING.md:
  https://github.com/configu/configu/blob/main/CONTRIBUTING.md

**Please** focus your PR on a single topic to avoid mixing unrelated changes.

Once you submit your PR, we’ll dive into it as soon as we can. We might come back with some suggestions or ask for some tweaks.

Thank you for your pull request!

---

## For Maintainers

Please ensure:
* [ ] The PR is linked to an issue and both are assigned to the same person
* [ ] The PR is labeled as either 'feat', 'bug', or 'chore'
* [ ] The changes have been approved by a reviewer
* [ ] The contributor checklist is fully addressed

-->

Closes #449 

It'd be nice if we could add some sort of validation when parsing the `.configu` file, to ensure that, among other things, we don't specify two `default` stores. However, since we don't currently have any form of runtime validation of the file, I figured it'd be a bit out of scope for this PR.