### PR TITLE
bugfix: fix ci super slow tests run

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "build": "tsc --build --verbose tsconfig.build.json",
     "build:integrations": "pnpm run --filter \"@configu-integrations/*\" build",
     "test": "tsx --test \"packages/**/src/**/*.test.ts\" \"packages/integrations/expressions/**/src/**/*.test.ts\" \"packages/integrations/formatters/**/src/**/*.test.ts\" \"packages/integrations/stores/**/src/**/*.test.ts\"",
-    "test:cov": "tsx --test --experimental-test-coverage --test-reporter=spec --test-reporter=lcov --test-reporter-destination=stdout --test-reporter-destination=lcov.info packages/**/src/**/*.test.ts",
-    "test:watch": "tsx --test --watch packages/**/src/**/*.test.ts",
+    "test:cov": "tsx --test --experimental-test-coverage --test-reporter=spec --test-reporter=lcov --test-reporter-destination=stdout --test-reporter-destination=lcov.info  \"packages/**/src/**/*.test.ts\" \"packages/integrations/expressions/**/src/**/*.test.ts\" \"packages/integrations/formatters/**/src/**/*.test.ts\" \"packages/integrations/stores/**/src/**/*.test.ts\"",
+    "test:watch": "tsx --test --watch  \"packages/**/src/**/*.test.ts\" \"packages/integrations/expressions/**/src/**/*.test.ts\" \"packages/integrations/formatters/**/src/**/*.test.ts\" \"packages/integrations/stores/**/src/**/*.test.ts\"",
     "start": "shx echo \"Interactive start script is coming soon <3\""
   },
   "devDependencies": {


### PR DESCRIPTION
the existing regex is looking for recursive node_modules tests inside the monorepo.