### PR TITLE
bugfix: disable auto-splitting of aws parameter store

### DIFF
--- a/packages/integrations/stores/aws-parameter-store/tsup.config.ts
+++ b/packages/integrations/stores/aws-parameter-store/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,


### PR DESCRIPTION
for some reason, AWS parameter store bundle is splitting into multiple files, which makes an issue if we want to lazy load it from ur public release.
other integrations don't, but I truly recommend adding this property to all integrations for future safety.