### PR TITLE
Fixed using the simple way suggested

### DIFF
--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig([
     // splitting: true,
     treeshake: true,
     noExternal: [/(.*)/],
+    splitting: false,
     // https://github.com/egoist/tsup/issues/939
     // outExtension: () => {
     //   return { js: '.js', dts: '.d.ts' };

--- a/packages/integrations/expressions/validator/tsup.config.ts
+++ b/packages/integrations/expressions/validator/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/formatters/CompactJSON/tsup.config.ts
+++ b/packages/integrations/formatters/CompactJSON/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/formatters/Dotenv/tsup.config.ts
+++ b/packages/integrations/formatters/Dotenv/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/formatters/HelmValues/tsup.config.ts
+++ b/packages/integrations/formatters/HelmValues/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/formatters/JSON/tsup.config.ts
+++ b/packages/integrations/formatters/JSON/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/formatters/KubernetesConfigMap/tsup.config.ts
+++ b/packages/integrations/formatters/KubernetesConfigMap/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/formatters/TOML/tsup.config.ts
+++ b/packages/integrations/formatters/TOML/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/formatters/TerraformTfvars/tsup.config.ts
+++ b/packages/integrations/formatters/TerraformTfvars/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/formatters/YAML/tsup.config.ts
+++ b/packages/integrations/formatters/YAML/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/stores/configu/tsup.config.ts
+++ b/packages/integrations/stores/configu/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/stores/csv-file/tsup.config.ts
+++ b/packages/integrations/stores/csv-file/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/stores/hashicorp-vault/tsup.config.ts
+++ b/packages/integrations/stores/hashicorp-vault/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/stores/json-file/tsup.config.ts
+++ b/packages/integrations/stores/json-file/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/stores/my-sql/tsup.config.ts
+++ b/packages/integrations/stores/my-sql/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/integrations/stores/sqlite/tsup.config.ts
+++ b/packages/integrations/stores/sqlite/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(async (): Promise<Options | Options[]> => {
     target: 'esnext',
     format: 'esm',
     noExternal: [/(.*)/],
+    splitting: false,
     outDir: `../../dist`,
     outExtension: () => ({
       js: `.os-${osName}.js`,

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     dts: true,
     sourcemap: true,
-    splitting: true,
+    splitting: false,
     treeshake: true,
     clean: true,
     keepNames: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,25 @@ importers:
         specifier: ^5.4.5
         version: 5.6.2
 
+  packages/integrations/stores/my-sql:
+    dependencies:
+      '@configu/integrations':
+        specifier: workspace:*
+        version: link:../..
+      '@configu/sdk':
+        specifier: workspace:*
+        version: link:../../../sdk
+    devDependencies:
+      '@types/node':
+        specifier: 20.12.12
+        version: 20.12.12
+      tsup:
+        specifier: 8.2.4
+        version: 8.2.4(jiti@2.0.0)(tsx@4.19.1)(typescript@5.6.2)(yaml@2.5.1)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.6.2
+
   packages/integrations/stores/sqlite:
     dependencies:
       '@configu/integrations':


### PR DESCRIPTION
The fix ensures integration bundle creates only one-file by adding `splitting: false,` to every tsup.config.ts file.