### PR TITLE
Extended Datetime Cfgu Types

### DIFF
--- a/packages/schema/.cfgu.json
+++ b/packages/schema/.cfgu.json
@@ -151,48 +151,6 @@
         },
         {
           "if": {
-            "properties": { "type": { "const": "DataSize" } }
-          },
-          "then": {
-            "properties": {
-              "pattern": {
-                "type": "string",
-                "default": "^\\d+(\\.\\d+)?(B|KB|MB|GB|TB|PB)$",
-                "description": "Regex pattern for data size validation"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": { "type": { "const": "Duration" } }
-          },
-          "then": {
-            "properties": {
-              "pattern": {
-                "type": "string",
-                "default": "^(\\d+[smhdwMy])+$",
-                "description": "Regex pattern for duration validation (e.g., 1h30m, 2d, 3w)"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": { "type": { "const": "DateFormat" } }
-          },
-          "then": {
-            "properties": {
-              "pattern": {
-                "type": "string",
-                "default": "^(yyyy|yy|MM|M|dd|d|HH|H|mm|m|ss|s)([.-/\\s]?(yyyy|yy|MM|M|dd|d|HH|H|mm|m|ss|s))*$",
-                "description": "Regex pattern for various date formats validation (yyyy-MM-dd, dd/MM/yyyy HH:mm:ss)"
-              }
-            }
-          }
-        },
-        {
-          "if": {
             "required": ["options"]
           },
           "then": {

--- a/packages/schema/.cfgu.json
+++ b/packages/schema/.cfgu.json
@@ -60,7 +60,10 @@
         "AlibabaRegion",
         "Language",
         "DateTime",
-        "ARN"
+        "Duration",
+        "DateFormat",
+        "ARN",
+        "DataSize"
       ]
     },
     "Cfgu": {
@@ -143,6 +146,48 @@
           "else": {
             "properties": {
               "schema": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "DataSize" } }
+          },
+          "then": {
+            "properties": {
+              "pattern": {
+                "type": "string",
+                "default": "^\\d+(\\.\\d+)?(B|KB|MB|GB|TB|PB)$",
+                "description": "Regex pattern for data size validation"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "Duration" } }
+          },
+          "then": {
+            "properties": {
+              "pattern": {
+                "type": "string",
+                "default": "^(\\d+[smhdwMy])+$",
+                "description": "Regex pattern for duration validation (e.g., 1h30m, 2d, 3w)"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "DateFormat" } }
+          },
+          "then": {
+            "properties": {
+              "pattern": {
+                "type": "string",
+                "default": "^(yyyy|yy|MM|M|dd|d|HH|H|mm|m|ss|s)([.-/\\s]?(yyyy|yy|MM|M|dd|d|HH|H|mm|m|ss|s))*$",
+                "description": "Regex pattern for various date formats validation (yyyy-MM-dd, dd/MM/yyyy HH:mm:ss)"
+              }
             }
           }
         },


### PR DESCRIPTION
# Closes #373 
1. Duration:

- Added a regex pattern: ^\d+[smhdwMy]$
   -  Description: Validates durations like 1h, 2d, 3w.

2. DateFormat:
- Added a regex pattern: ^(yyyy|yy|MM|M|dd|d|HH|H|mm|m|ss|s)([.-/\s]?(yyyy|yy|MM|M|dd|d|HH|H|mm|m|ss|s))*$
    - Description: Ensures date formats like yyyy-MM-dd or dd/MM/yyyy HH:mm:ss are valid
