### PR TITLE
Fix `@configu-integrations/validator` registration in `@configu/common`

### DIFF
--- a/packages/common/src/Registry.ts
+++ b/packages/common/src/Registry.ts
@@ -31,6 +31,8 @@ export class Registry {
         // console.log('Registering ConfigStore:', value.type);
         Registry.store.set(value.type, value);
       } else if (Registry.isExpression(value)) {
+        const existingExpressionKeys = Array.from(Expression.functions.keys());
+        if (existingExpressionKeys.includes(key)) return;
         // console.log('Registering Expression:', key);
         if (key.endsWith(expressionOptionalSuffix)) {
           Expression.register({ key: key.slice(0, -expressionOptionalSuffix.length), fn: value });

--- a/packages/common/src/built-in-integrations.ts
+++ b/packages/common/src/built-in-integrations.ts
@@ -1,4 +1,4 @@
-import * as validators from '@configu-integrations/validator';
+import validators from '@configu-integrations/validator';
 import { CompactJSON } from '@configu-integrations/compact-json';
 import { JSONExpression } from '@configu-integrations/json';
 import { Dotenv } from '@configu-integrations/dotenv';
@@ -9,8 +9,8 @@ import { NoopConfigStore, InMemoryConfigStore } from '@configu/sdk';
 
 import { Registry } from './Registry';
 
-Registry.register(validators);
 Registry.register({
+  ...validators.default,
   CompactJSON,
   JSONExpression,
   Dotenv,

--- a/packages/integrations/expressions/validator/src/validators.ts
+++ b/packages/integrations/expressions/validator/src/validators.ts
@@ -1,1 +1,3 @@
-export * from 'validator';
+import validator from 'validator';
+
+export default validator;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the pull request (PR) is created. -->

<!--
Thank you for contributing to Configu! We really appreciate your efforts to make Configu better.

Looking to send a PR? Awesome! You can find many issues labeled as `help wanted` or `good first issue` in our issue tracker.
  https://github.com/configu/configu/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22%2C%22help+wanted%22

Before you send over your PR, let's ensure it’s all set for a smooth review. Here’s a quick checklist:

Please verify that:
* [ ] The PR has a clear title and a concise summary of the changes (Use the present tense and imperative mood for your descriptions)
* [ ] Related issues are linked using `Closes #number`
* [ ] Code is up-to-date with the `main` branch
* [ ] There are no linting or formatting errors
* [ ] There are new or updated unit tests validating the change

For more details, have a look at our CONTRIBUTING.md:
  https://github.com/configu/configu/blob/main/CONTRIBUTING.md

**Please** focus your PR on a single topic to avoid mixing unrelated changes.

Once you submit your PR, we’ll dive into it as soon as we can. We might come back with some suggestions or ask for some tweaks.

Thank you for your pull request!

---

## For Maintainers

Please ensure:
* [ ] The PR is linked to an issue and both are assigned to the same person
* [ ] The PR is labeled as either 'feat', 'bug', or 'chore'
* [ ] The changes have been approved by a reviewer
* [ ] The contributor checklist is fully addressed

-->

Closes #607.

The `Registry.register` method skips non-function registration while validator was provided to the registry in it's entirety as an object which results in the registration doing nothing. To fix this, the validator functions are now registered individually. This required an adjustment in how the validator package is exported.

Side note: Validator has functions that conflict with existing functions provided natively by `adaptive-expressions` so I added logic that skips registrations of duplicate functions because attempting overrides causes the library to throw errors. 

Considering that the `adaptive-expression` library will probably be replaced as mentioned by @rannn505, I think this is a decent workaround for now. 
