### PR TITLE
bug: fix status-code for store not found

### DIFF
--- a/packages/proxy/src/error/not-found.ts
+++ b/packages/proxy/src/error/not-found.ts
@@ -1,0 +1,12 @@
+import { FastifyError } from 'fastify';
+
+export class NotFoundError implements FastifyError {
+  code: string = 'FST_ERR_NOT_FOUND';
+  name: string = 'NotFoundError';
+  message: string;
+  statusCode: number = 404;
+
+  constructor(message: string = 'Item not found') {
+    this.message = message;
+  }
+}

--- a/packages/proxy/src/routes.ts
+++ b/packages/proxy/src/routes.ts
@@ -11,6 +11,7 @@ import {
 } from '@configu/sdk';
 import _ from 'lodash';
 import { ConfiguFile } from '@configu/common';
+import { NotFoundError } from './error/not-found';
 import { config } from './config';
 
 const body = {
@@ -95,7 +96,7 @@ export const routes: FastifyPluginAsync = async (server, opts): Promise<void> =>
 
           const storeInstance = configuFile.getStoreInstance(store);
           if (!storeInstance) {
-            throw new Error(`store "${store}" not found`);
+            throw new NotFoundError(`store "${store}" not found`);
           }
           const setInstance = new ConfigSet(set);
           const schemaInstance = new ConfigSchema(keys);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the pull request (PR) is created. -->

<!--
Thank you for contributing to Configu! We really appreciate your efforts to make Configu better.

Looking to send a PR? Awesome! You can find many issues labeled as `help wanted` or `good first issue` in our issue tracker.
  https://github.com/configu/configu/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22%2C%22help+wanted%22

Before you send over your PR, let's ensure it’s all set for a smooth review. Here’s a quick checklist:

Please verify that:
* [ ] The PR has a clear title and a concise summary of the changes (Use the present tense and imperative mood for your descriptions)
* [ ] Related issues are linked using `Closes #number`
* [ ] Code is up-to-date with the `main` branch
* [ ] There are no linting or formatting errors
* [ ] There are new or updated unit tests validating the change

For more details, have a look at our CONTRIBUTING.md:
  https://github.com/configu/configu/blob/main/CONTRIBUTING.md

**Please** focus your PR on a single topic to avoid mixing unrelated changes.

Once you submit your PR, we’ll dive into it as soon as we can. We might come back with some suggestions or ask for some tweaks.

Thank you for your pull request!

---

## For Maintainers

Please ensure:
* [ ] The PR is linked to an issue and both are assigned to the same person
* [ ] The PR is labeled as either 'feat', 'bug', or 'chore'
* [ ] The changes have been approved by a reviewer
* [ ] The contributor checklist is fully addressed

-->

Closes #655 

# Summary
This MR fixes an issue where attempting to export a non-existing store returned an incorrect status code (500 instead of 404). The response now correctly returns a 404 status code with a message indicating that the store was not found.

## Changes
* Added a custom NotFoundError class to handle cases where a requested store does not exist.
* Updated the controller to throw NotFoundError when the store is not found. 
Explanation:   
When an error is thrown in Fastify (like NotFoundError), the framework’s default error handler automatically intercepts it. If the error object includes a statusCode property, Fastify will set the response’s status code to this value. This means that by simply throwing an error with a custom statusCode, Fastify will correctly format and send the response based on the error's properties without needing extra configuration.     
[see docs](https://fastify.dev/docs/v4.28.x/Reference/Errors/#fastify-error-codes:~:text=The%20root%20error%20handler%20is%20Fastify%27s%20generic%20error%20handler.%20This%20error%20handler%20will%20use%20the%20headers%20and%20status%20code%20in%20the%20Error%20object%2C%20if%20they%20exist.)


Example Response
```json
{
    "code": "FST_ERR_NOT_FOUND",
    "name": "NotFoundError",
    "message": "store \"mainStore\" not found",
    "statusCode": 404
}
```







